### PR TITLE
Add `allow_errors_in_values` argument to register

### DIFF
--- a/src/nme/_serialize_hooks.py
+++ b/src/nme/_serialize_hooks.py
@@ -143,8 +143,13 @@ def nme_object_hook(dkt: dict) -> typing.Any:
             cls_str = dkt.pop("__class__")
             version_dkt = dkt.pop("__class_version_dkt__") if "__class_version_dkt__" in dkt else {cls_str: "0.0.0"}
             dkt = {"__values__": dkt, "__class__": cls_str, "__class_version_dkt__": version_dkt}
+        try:
+            cls = REGISTER.get_class(dkt["__class__"])
+        except (KeyError, ValueError):
+            dkt["__error__"] = f"Class {dkt['__class__']} not found in register."
+            return dkt
         problematic_fields = check_for_errors_in_dkt_values(dkt["__values__"])
-        if problematic_fields:
+        if problematic_fields and not REGISTER.allow_errors_in_values(cls):
             dkt["__error__"] = f"Error in fields: {', '.join(problematic_fields)}"
             return dkt
         try:

--- a/src/tests/test_class_register.py
+++ b/src/tests/test_class_register.py
@@ -165,3 +165,16 @@ def test_missed_class(clean_register):
         REGISTER.get_class("nme.not_package.not_module.NotClass")
     with pytest.raises(ValueError, match=r"Class [\w\.]+ not found"):
         REGISTER.get_class("nme_not.not_package.not_module.NotClass")
+
+
+def test_allow_errors(clean_register):
+    @register_class
+    class _SampleClass1:
+        pass
+
+    @register_class(allow_errors_in_values=True)
+    class _SampleClass2:
+        pass
+
+    assert not REGISTER.allow_errors_in_values(_SampleClass1)
+    assert REGISTER.allow_errors_in_values(_SampleClass2)


### PR DESCRIPTION
This PR adds an option to ignore if some fields have errors when deserializing. 

The main idea is to not bloc of creation of custom containers that are allowed to contain broken entries. 